### PR TITLE
Refactor confirmation dialogs under a share component

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,6 +47,9 @@
           80,
           120
         ],
+        "editor.pasteAs.preferences": [
+          "text.updateImports.jsts"
+        ],
         "editor.wordWrap": "wordWrapColumn",
         "editor.wordWrapColumn": 120,
         "editor.formatOnSave": true,

--- a/webapp/app/modules/accounts/components/dialogs/archive.tsx
+++ b/webapp/app/modules/accounts/components/dialogs/archive.tsx
@@ -1,14 +1,4 @@
-import { Throbber } from "~/shared/components/throbber";
-import { Button } from "~/shared/components/ui/button";
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle
-} from "~/shared/components/ui/drawer";
+import { ConfirmationDialog } from "~/shared/components/dialogs/confirmation";
 import { Account } from "../../types/account";
 
 interface Props {
@@ -23,25 +13,8 @@ export function ArchiveAccount({ account, open, onOpenChange, onConfirm, submitt
   const { id, name, additionalData: { transactions } } = account
 
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent>
-        <DrawerHeader>
-          <DrawerTitle>Are you sure?</DrawerTitle>
-          <DrawerDescription className="space-y-2">
-            You are about to archive <span className="font-bold">{name}</span>. This will remove it as an selectable option from the rest of <span className="font-bold text-foreground">financo</span> while preserving its <span className="font-bold">{transactions}</span> transaction(s) in your ledger. <span className="font-bold">This action can be reverted from the Accounts archive</span>.
-          </DrawerDescription>
-        </DrawerHeader>
-        <DrawerFooter>
-          <Button onClick={() => onConfirm(id)} disabled={submitting}>
-            {submitting ? <Throbber size={"sm"} /> : "Confirm"}
-          </Button>
-          <DrawerClose asChild>
-            <Button variant={"outline"} disabled={submitting}>
-              Cancel
-            </Button>
-          </DrawerClose>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+    <ConfirmationDialog open={open} onOpenChange={onOpenChange} onConfirm={() => onConfirm(id)} submitting={submitting}>
+      You are about to archive <span className="font-bold">{name}</span>. This will remove it as an selectable option from the rest of <span className="font-bold text-foreground">financo</span> while preserving its <span className="font-bold">{transactions}</span> transaction(s) in your ledger. <span className="font-bold">This action can be reverted from the Accounts archive</span>.
+    </ConfirmationDialog>
   )
 }

--- a/webapp/app/modules/accounts/components/dialogs/delete.tsx
+++ b/webapp/app/modules/accounts/components/dialogs/delete.tsx
@@ -1,14 +1,4 @@
-import { Throbber } from "~/shared/components/throbber";
-import { Button } from "~/shared/components/ui/button";
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle
-} from "~/shared/components/ui/drawer";
+import { ConfirmationDialog } from "~/shared/components/dialogs/confirmation";
 import { Account } from "../../types/account";
 
 interface Props {
@@ -23,25 +13,8 @@ export function DeleteAccount({ account, open, onOpenChange, onConfirm, submitti
   const { id, name, additionalData: { transactions } } = account
 
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent>
-        <DrawerHeader>
-          <DrawerTitle>Are you absolutely sure?</DrawerTitle>
-          <DrawerDescription className="space-y-2">
-            You are about to permanently delete <span className="font-bold">{name}</span> from your Accounts and its related <span className="font-bold">{transactions}</span> transaction(s) from your ledger. <span className="font-bold">This action cannot be undone</span>.
-          </DrawerDescription>
-        </DrawerHeader>
-        <DrawerFooter>
-          <Button onClick={() => onConfirm(id)} disabled={submitting}>
-            {submitting ? <Throbber size={"sm"} /> : "Confirm"}
-          </Button>
-          <DrawerClose asChild>
-            <Button variant={"outline"} disabled={submitting}>
-              Cancel
-            </Button>
-          </DrawerClose>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+    <ConfirmationDialog open={open} onOpenChange={onOpenChange} onConfirm={() => onConfirm(id)} submitting={submitting}>
+      You are about to permanently delete <span className="font-bold">{name}</span> from your Accounts and its related <span className="font-bold">{transactions}</span> transaction(s) from your ledger. <span className="font-bold">This action cannot be undone</span>.
+    </ConfirmationDialog>
   )
 }

--- a/webapp/app/modules/accounts/components/dialogs/unarchive.tsx
+++ b/webapp/app/modules/accounts/components/dialogs/unarchive.tsx
@@ -1,14 +1,4 @@
-import { Throbber } from "~/shared/components/throbber";
-import { Button } from "~/shared/components/ui/button";
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle
-} from "~/shared/components/ui/drawer";
+import { ConfirmationDialog } from "~/shared/components/dialogs/confirmation";
 import { Account } from "../../types/account";
 
 interface Props {
@@ -23,25 +13,8 @@ export function UnarchiveAccount({ account, open, onOpenChange, onConfirm, submi
   const { id, name } = account
 
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent>
-        <DrawerHeader>
-          <DrawerTitle>Are you sure?</DrawerTitle>
-          <DrawerDescription className="space-y-2">
-            You are about to unarchive <span className="font-bold">{name}</span>. This will make it reappear as an selectable option in <span className="font-bold text-foreground">financo</span>. <span className="font-bold">This action can be reverted from the Accounts</span>.
-          </DrawerDescription>
-        </DrawerHeader>
-        <DrawerFooter>
-          <Button onClick={() => onConfirm(id)} disabled={submitting}>
-            {submitting ? <Throbber size={"sm"} /> : "Confirm"}
-          </Button>
-          <DrawerClose asChild>
-            <Button variant={"outline"} disabled={submitting}>
-              Cancel
-            </Button>
-          </DrawerClose>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+    <ConfirmationDialog open={open} onOpenChange={onOpenChange} onConfirm={() => onConfirm(id)} submitting={submitting}>
+      You are about to unarchive <span className="font-bold">{name}</span>. This will make it reappear as an selectable option in <span className="font-bold text-foreground">financo</span>. <span className="font-bold">This action can be reverted from the Accounts</span>.
+    </ConfirmationDialog>
   )
 }

--- a/webapp/app/modules/accounts/components/forms/create.tsx
+++ b/webapp/app/modules/accounts/components/forms/create.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import moment from "moment";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { InfoDialog } from "~/shared/components/dialogs/info";
@@ -106,6 +106,7 @@ function CreateForm({ kind, defaultCurrency, defaultIcon, submitting, onSubmitAc
         debt_loan: "#fc004f",
         debt_personal: "#00fc4b",
       }[kind],
+      history: {},
       icon: defaultIcon,
       main: false,
     }
@@ -130,6 +131,16 @@ function CreateForm({ kind, defaultCurrency, defaultIcon, submitting, onSubmitAc
       return value
     })
   }
+
+  useEffect(() => {
+
+  }, [])
+
+  useEffect(() => {
+    if (Object.keys(form.formState.errors).length === 0) return
+
+    console.error(form.formState.errors)
+  }, [form.formState.errors])
 
   return (
     <Form {...form}>

--- a/webapp/app/modules/categories/components/dialogs/archive.tsx
+++ b/webapp/app/modules/categories/components/dialogs/archive.tsx
@@ -1,14 +1,4 @@
-import { Throbber } from "~/shared/components/throbber";
-import { Button } from "~/shared/components/ui/button";
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle
-} from "~/shared/components/ui/drawer";
+import { ConfirmationDialog } from "~/shared/components/dialogs/confirmation";
 
 interface Props {
   open: boolean
@@ -30,25 +20,8 @@ export function ArchiveDialog({
   submitting
 }: Props) {
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent>
-        <DrawerHeader>
-          <DrawerTitle>Are you sure?</DrawerTitle>
-          <DrawerDescription className="space-y-2">
-            You are about to archive <span className="font-bold">{name}</span>. This will remove it as an selectable option from the rest of <span className="font-bold text-foreground">financo</span> while preserving its <span className="font-bold">{transactions}</span> transaction(s) in your ledger and its <span className="font-bold">{childrenCount}</span> child(ren). <span className="font-bold">This action can be reverted from the Categories archive</span>.
-          </DrawerDescription>
-        </DrawerHeader>
-        <DrawerFooter>
-          <Button onClick={onConfirm} disabled={submitting}>
-            {submitting ? <Throbber size={"sm"} /> : "Confirm"}
-          </Button>
-          <DrawerClose asChild>
-            <Button variant={"outline"} disabled={submitting}>
-              Cancel
-            </Button>
-          </DrawerClose>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+    <ConfirmationDialog open={open} onOpenChange={onOpenChange} onConfirm={onConfirm} submitting={submitting}>
+      You are about to archive <span className="font-bold">{name}</span>. This will remove it as an selectable option from the rest of <span className="font-bold text-foreground">financo</span> while preserving its <span className="font-bold">{transactions}</span> transaction(s) in your ledger and its <span className="font-bold">{childrenCount}</span> child(ren). <span className="font-bold">This action can be reverted from the Categories archive</span>.
+    </ConfirmationDialog>
   )
 }

--- a/webapp/app/modules/categories/components/dialogs/child/archive.tsx
+++ b/webapp/app/modules/categories/components/dialogs/child/archive.tsx
@@ -1,14 +1,4 @@
-import { Throbber } from "~/shared/components/throbber";
-import { Button } from "~/shared/components/ui/button";
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle
-} from "~/shared/components/ui/drawer";
+import { ConfirmationDialog } from "~/shared/components/dialogs/confirmation";
 
 interface Props {
   open: boolean
@@ -28,25 +18,8 @@ export function ArchiveDialog({
   submitting
 }: Props) {
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent>
-        <DrawerHeader>
-          <DrawerTitle>Are you sure?</DrawerTitle>
-          <DrawerDescription className="space-y-2">
-            You are about to archive <span className="font-bold">{name}</span>. This will remove it as an selectable option from the rest of <span className="font-bold text-foreground">financo</span> while preserving its <span className="font-bold">{transactions}</span> transaction(s) in your ledger. <span className="font-bold">This action can be reverted from the Categories archive</span>.
-          </DrawerDescription>
-        </DrawerHeader>
-        <DrawerFooter>
-          <Button onClick={onConfirm} disabled={submitting}>
-            {submitting ? <Throbber size={"sm"} /> : "Confirm"}
-          </Button>
-          <DrawerClose asChild>
-            <Button variant={"outline"} disabled={submitting}>
-              Cancel
-            </Button>
-          </DrawerClose>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+    <ConfirmationDialog open={open} onOpenChange={onOpenChange} onConfirm={onConfirm} submitting={submitting}>
+      You are about to archive <span className="font-bold">{name}</span>. This will remove it as an selectable option from the rest of <span className="font-bold text-foreground">financo</span> while preserving its <span className="font-bold">{transactions}</span> transaction(s) in your ledger. <span className="font-bold">This action can be reverted from the Categories archive</span>.
+    </ConfirmationDialog>
   )
 }

--- a/webapp/app/modules/categories/components/dialogs/child/delete.tsx
+++ b/webapp/app/modules/categories/components/dialogs/child/delete.tsx
@@ -1,14 +1,4 @@
-import { Throbber } from "~/shared/components/throbber";
-import { Button } from "~/shared/components/ui/button";
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle
-} from "~/shared/components/ui/drawer";
+import { ConfirmationDialog } from "~/shared/components/dialogs/confirmation";
 
 interface Props {
   open: boolean
@@ -28,25 +18,8 @@ export function DeleteDialog({
   submitting
 }: Props) {
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent>
-        <DrawerHeader>
-          <DrawerTitle>Are you absolutely sure?</DrawerTitle>
-          <DrawerDescription className="space-y-2">
-            You are about to permanently delete <span className="font-bold">{name}</span> from your Categories and its related <span className="font-bold">{transactions}</span> transaction(s) from your ledger. <span className="font-bold">This action cannot be undone</span>.
-          </DrawerDescription>
-        </DrawerHeader>
-        <DrawerFooter>
-          <Button onClick={onConfirm} disabled={submitting}>
-            {submitting ? <Throbber size={"sm"} /> : "Confirm"}
-          </Button>
-          <DrawerClose asChild>
-            <Button variant={"outline"} disabled={submitting}>
-              Cancel
-            </Button>
-          </DrawerClose>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+    <ConfirmationDialog open={open} onOpenChange={onOpenChange} onConfirm={onConfirm} submitting={submitting}>
+      You are about to permanently delete <span className="font-bold">{name}</span> from your Categories and its related <span className="font-bold">{transactions}</span> transaction(s) from your ledger. <span className="font-bold">This action cannot be undone</span>.
+    </ConfirmationDialog>
   )
 }

--- a/webapp/app/modules/categories/components/dialogs/child/unarchive.tsx
+++ b/webapp/app/modules/categories/components/dialogs/child/unarchive.tsx
@@ -1,14 +1,4 @@
-import { Throbber } from "~/shared/components/throbber";
-import { Button } from "~/shared/components/ui/button";
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle
-} from "~/shared/components/ui/drawer";
+import { ConfirmationDialog } from "~/shared/components/dialogs/confirmation";
 
 interface Props {
   open: boolean
@@ -26,25 +16,8 @@ export function UnarchiveDialog({
   submitting
 }: Props) {
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent>
-        <DrawerHeader>
-          <DrawerTitle>Are you sure?</DrawerTitle>
-          <DrawerDescription className="space-y-2">
-            You are about to unarchive <span className="font-bold">{name}</span>. This will make it reappear as an selectable option in <span className="font-bold text-foreground">financo</span>. <span className="font-bold">This action can be reverted from the Categories</span>.
-          </DrawerDescription>
-        </DrawerHeader>
-        <DrawerFooter>
-          <Button onClick={onConfirm} disabled={submitting}>
-            {submitting ? <Throbber size={"sm"} /> : "Confirm"}
-          </Button>
-          <DrawerClose asChild>
-            <Button variant={"outline"} disabled={submitting}>
-              Cancel
-            </Button>
-          </DrawerClose>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+    <ConfirmationDialog open={open} onOpenChange={onOpenChange} onConfirm={onConfirm} submitting={submitting}>
+      You are about to unarchive <span className="font-bold">{name}</span>. This will make it reappear as an selectable option in <span className="font-bold text-foreground">financo</span>. <span className="font-bold">This action can be reverted from the Categories</span>.
+    </ConfirmationDialog>
   )
 }

--- a/webapp/app/modules/categories/components/dialogs/delete.tsx
+++ b/webapp/app/modules/categories/components/dialogs/delete.tsx
@@ -1,14 +1,4 @@
-import { Throbber } from "~/shared/components/throbber";
-import { Button } from "~/shared/components/ui/button";
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle
-} from "~/shared/components/ui/drawer";
+import { ConfirmationDialog } from "~/shared/components/dialogs/confirmation";
 
 interface Props {
   open: boolean
@@ -30,25 +20,8 @@ export function DeleteDialog({
   submitting
 }: Props) {
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent>
-        <DrawerHeader>
-          <DrawerTitle>Are you absolutely sure?</DrawerTitle>
-          <DrawerDescription className="space-y-2">
-            You are about to permanently delete <span className="font-bold">{name}</span> from your Categories and its related <span className="font-bold">{transactions}</span> transaction(s) from your ledger and its <span className="font-bold">{childrenCount}</span> child(ren). <span className="font-bold">This action cannot be undone</span>.
-          </DrawerDescription>
-        </DrawerHeader>
-        <DrawerFooter>
-          <Button onClick={onConfirm} disabled={submitting}>
-            {submitting ? <Throbber size={"sm"} /> : "Confirm"}
-          </Button>
-          <DrawerClose asChild>
-            <Button variant={"outline"} disabled={submitting}>
-              Cancel
-            </Button>
-          </DrawerClose>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+    <ConfirmationDialog open={open} onOpenChange={onOpenChange} onConfirm={onConfirm} submitting={submitting}>
+      You are about to permanently delete <span className="font-bold">{name}</span> from your Categories and its related <span className="font-bold">{transactions}</span> transaction(s) from your ledger and its <span className="font-bold">{childrenCount}</span> child(ren). <span className="font-bold">This action cannot be undone</span>.
+    </ConfirmationDialog>
   )
 }

--- a/webapp/app/modules/categories/components/dialogs/unarchive.tsx
+++ b/webapp/app/modules/categories/components/dialogs/unarchive.tsx
@@ -1,14 +1,4 @@
-import { Throbber } from "~/shared/components/throbber";
-import { Button } from "~/shared/components/ui/button";
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle
-} from "~/shared/components/ui/drawer";
+import { ConfirmationDialog } from "~/shared/components/dialogs/confirmation";
 
 interface Props {
   open: boolean
@@ -28,25 +18,8 @@ export function UnarchiveDialog({
   submitting
 }: Props) {
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent>
-        <DrawerHeader>
-          <DrawerTitle>Are you sure?</DrawerTitle>
-          <DrawerDescription className="space-y-2">
-            You are about to unarchive <span className="font-bold">{name}</span> and its <span className="font-bold">{childrenCount}</span> child(ren). This will make it reappear as an selectable option in <span className="font-bold text-foreground">financo</span>. <span className="font-bold">This action can be reverted from the Categories</span>.
-          </DrawerDescription>
-        </DrawerHeader>
-        <DrawerFooter>
-          <Button onClick={onConfirm} disabled={submitting}>
-            {submitting ? <Throbber size={"sm"} /> : "Confirm"}
-          </Button>
-          <DrawerClose asChild>
-            <Button variant={"outline"} disabled={submitting}>
-              Cancel
-            </Button>
-          </DrawerClose>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+    <ConfirmationDialog open={open} onOpenChange={onOpenChange} onConfirm={onConfirm} submitting={submitting}>
+      You are about to unarchive <span className="font-bold">{name}</span> and its <span className="font-bold">{childrenCount}</span> child(ren). This will make it reappear as an selectable option in <span className="font-bold text-foreground">financo</span>. <span className="font-bold">This action can be reverted from the Categories</span>.
+    </ConfirmationDialog>
   )
 }

--- a/webapp/app/shared/components/dialogs/confirm-async-action.tsx
+++ b/webapp/app/shared/components/dialogs/confirm-async-action.tsx
@@ -1,0 +1,50 @@
+import { PropsWithChildren } from "react";
+import { Throbber } from "~/shared/components/throbber";
+import { Button } from "~/shared/components/ui/button";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle
+} from "~/shared/components/ui/drawer";
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+  submitting: boolean
+}
+
+export function ConfirmAsyncActionDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  submitting,
+  children
+}: PropsWithChildren<Props>) {
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>Are you sure?</DrawerTitle>
+          <DrawerDescription className="space-y-2">
+            {children}
+          </DrawerDescription>
+        </DrawerHeader>
+        <DrawerFooter>
+          <Button onClick={onConfirm} disabled={submitting}>
+            {submitting ? <Throbber size={"sm"} /> : "Confirm"}
+          </Button>
+          <DrawerClose asChild>
+            <Button variant={"outline"} disabled={submitting}>
+              Cancel
+            </Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  )
+}

--- a/webapp/app/shared/components/dialogs/confirmation.tsx
+++ b/webapp/app/shared/components/dialogs/confirmation.tsx
@@ -18,7 +18,7 @@ interface Props {
   submitting: boolean
 }
 
-export function ConfirmAsyncActionDialog({
+export function ConfirmationDialog({
   open,
   onOpenChange,
   onConfirm,


### PR DESCRIPTION
I have too many confirmation dialogs in the current webapp so is better to unify them under a shared component